### PR TITLE
Remove quantified constraints in Functor,Foldable,Traversable instanc…

### DIFF
--- a/Data/Bifunctor/Product.hs
+++ b/Data/Bifunctor/Product.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE QuantifiedConstraints #-}
 
 module Data.Bifunctor.Product where
 
@@ -9,13 +8,13 @@ import Data.Bitraversable (Bitraversable (..))
 
 data Product f g a b = Pair { fst :: f a b, snd :: g a b }
 
-instance (forall a. Foldable (f a), forall a. Foldable (g a)) => Foldable (Product f g a) where
+instance (Foldable (f a), Foldable (g a)) => Foldable (Product f g a) where
     foldMap f (Pair x y) = foldMap f x <> foldMap f y
 
-instance (forall a. Functor (f a), forall a. Functor (g a)) => Functor (Product f g a) where
+instance (Functor (f a), Functor (g a)) => Functor (Product f g a) where
     fmap f (Pair x y) = Pair (fmap f x) (fmap f y)
 
-instance (forall a. Traversable (f a), forall a. Traversable (g a)) => Traversable (Product f g a) where
+instance (Traversable (f a), Traversable (g a)) => Traversable (Product f g a) where
     traverse f (Pair x y) = Pair <$> traverse f x <*> traverse f y
 
 instance (Bifoldable f, Bifoldable g) => Bifoldable (Product f g) where


### PR DESCRIPTION
I had unecessarily used quantified constraints in https://github.com/strake/hs-functors.hs/pull/2.

If you want to make this version without quantified constraints compile with very old GHCs (version 7.10 or older), you will have to add the FlexibleContexts language extension.